### PR TITLE
operationId overrides generated operationId

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,18 @@ http: {
 }
 ```
 
+### Custom operationId
+
+You can override the automatically generated operationId by adding the `operationId` property to the http event. This can be useful when using code generators.
+
+```js
+http: {
+    path: 'hello',
+    method: 'post',
+    operationId: 'postHello',
+}
+```
+
 ### MIME Types
 
 You can specify the MIME types by adding `consumes` and `produces` to the http event. Default for both is `['application/json']`

--- a/src/ServerlessAutoSwagger.ts
+++ b/src/ServerlessAutoSwagger.ts
@@ -256,7 +256,7 @@ export default class ServerlessAutoSwagger {
       summary: http.summary || functionName,
       description: http.description ?? '',
       tags: http.swaggerTags,
-      operationId: `${functionName}.${method}.${http.path}`,
+      operationId: http.operationId || `${functionName}.${method}.${http.path}`,
       consumes: http.consumes ?? ['application/json'],
       produces: http.produces ?? ['application/json'],
       // This is actually type `HttpEvent | HttpApiEvent`, but we can lie since only HttpEvent params (or shared params) are used

--- a/src/types/serverless-plugin.types.d.ts
+++ b/src/types/serverless-plugin.types.d.ts
@@ -110,6 +110,7 @@ export interface CustomHttpEvent extends Http {
   bodyType?: string;
   headerParameters?: HeaderParameters;
   queryStringParameters?: QueryStringParameters;
+  operationId?: string;
 }
 
 export interface CustomHttpApiEvent extends HttpApiEvent {
@@ -125,6 +126,7 @@ export interface CustomHttpApiEvent extends HttpApiEvent {
   bodyType?: string;
   headerParameters?: string;
   queryStringParameterType?: string;
+  operationId?: string;
 }
 
 export interface HttpResponses {

--- a/tests/ServerlessAutoSwagger.test.ts
+++ b/tests/ServerlessAutoSwagger.test.ts
@@ -989,4 +989,43 @@ describe('ServerlessAutoSwagger', () => {
       });
     });
   });
+
+  describe('overrideOperationId', () => {
+    it('should use defaults if overrides are not specified', () => {
+      const serverlessAutoSwagger = new ServerlessAutoSwagger(
+        generateServerlessFromAnEndpoint([
+          {
+            http: {
+              path: 'hello',
+              method: 'post',
+            },
+          },
+        ]),
+        options,
+        logging
+      );
+      serverlessAutoSwagger.generatePaths();
+
+      expect(serverlessAutoSwagger.swagger.paths['/hello'].post?.operationId).toBe('mocked.post.hello');
+    });
+
+    it('should use operationId override if specified', () => {
+      const serverlessAutoSwagger = new ServerlessAutoSwagger(
+        generateServerlessFromAnEndpoint([
+          {
+            http: {
+              path: 'hello',
+              method: 'post',
+              operationId: 'postHello',
+            },
+          },
+        ]),
+        options,
+        logging
+      );
+      serverlessAutoSwagger.generatePaths();
+
+      expect(serverlessAutoSwagger.swagger.paths['/hello'].post?.operationId).toBe('postHello');
+    });
+  });
 });


### PR DESCRIPTION
I had a use case where I needed to generate a client side api client using openapi-generator-cli. I wanted custom function names that are controlled by the operationId parameter.

This PR adds the ability to override the default generated operationId as a property on the http event. 
Example: 
```ts
{
    http: {
      method: 'get',
      path: '/booking-request/{id}/timeslots',
      operationId: "getTimeslotsByBookingRequestId"
    }
  }
}
```