### PR TITLE
Security Definition Updates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,14 +14,7 @@ module.exports = {
   },
   rules: {
     // 0 = off; 1 = warning; 2 = error
-    'no-unused-vars': [
-      'warn',
-      {
-        argsIgnorePattern: '^_',
-        varsIgnorePattern: '^_',
-        caughtErrorsIgnorePattern: '^_',
-      },
-    ],
+    'no-unused-vars': 0, // For Typescript, this has to be handled with the TS plugin instead (automatically)
     'no-console': 0,
     'no-restricted-syntax': 0,
     'no-undef': 1,
@@ -34,7 +27,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 0,
     'deprecation/deprecation': 1,
     '@typescript-eslint/no-explicit-any': 0, // Ideally we want this on, but we have some types that I'm unfamiliar with typed as `any`.
-    '@typescript-eslint/no-unused-vars': 0,
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,14 @@ module.exports = {
   },
   rules: {
     // 0 = off; 1 = warning; 2 = error
-    'no-unused-vars': 0, // For Typescript, this has to be handled with the TS plugin instead (automatically)
+    'no-unused-vars': [
+      'warn',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
     'no-console': 0,
     'no-restricted-syntax': 0,
     'no-undef': 1,
@@ -27,6 +34,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 0,
     'deprecation/deprecation': 1,
     '@typescript-eslint/no-explicit-any': 0, // Ideally we want this on, but we have some types that I'm unfamiliar with typed as `any`.
+    '@typescript-eslint/no-unused-vars': 0,
   },
   overrides: [
     {

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ custom:
         host: 'http://some-host'
         schemes: ['http', 'https', 'ws', 'wss']
         excludeStages: ['production', 'anyOtherStage']
-        lambdaAuthorizer?: ${self:custom.myAuthorizer}
+        lambdaAuthorizer: ${self:custom.myAuthorizer}
+        useRedirectUI: true | false
 ```
 
 | Option                    | Description                                                                                                           | Default                                                                    | Example                                                  |
@@ -68,6 +69,7 @@ custom:
 | `version`                 | String to overwrite the project version with a custom one                                                             | `1`                                                                        |                                                          |
 | `typefiles`               | Array of strings which defines where to find the typescript types to use for the request and response bodies          | `['./src/types/api-types.d.ts']`                                           |                                                          |
 | `useStage`                | Boolean to either use current stage in beginning of path or not                                                       | `false`                                                                    | `true` => `dev/swagger` for stage `dev`                  |
+| `useRedirectUI`           | Boolean to include a path and handler for the oauth2 redirect flow or not                                             | `false`                                                                    |                                                          |
 
 ## Adding more details
 

--- a/src/ServerlessAutoSwagger.ts
+++ b/src/ServerlessAutoSwagger.ts
@@ -20,7 +20,6 @@ import type {
   PathParameters,
   QueryStringParameters,
   ServerlessCommand,
-  ServerlessFunction,
   ServerlessHooks,
 } from './types/serverless-plugin.types';
 
@@ -236,15 +235,7 @@ export default class ServerlessAutoSwagger {
   addEndpointsAndLambda = () => {
     this.serverless.service.functions = {
       ...this.serverless.service.functions,
-      ...Object.entries(swaggerFunctions(this.serverless))
-        .filter(([_key, value]) => value)
-        .reduce(
-          (acc, [key, value]) => ({
-            ...acc,
-            [key]: value as ServerlessFunction,
-          }),
-          {}
-        ),
+      ...swaggerFunctions(this.serverless),
     };
   };
 

--- a/src/resources/functions.ts
+++ b/src/resources/functions.ts
@@ -1,9 +1,11 @@
 'use strict';
 import { ApiType, CustomHttpApiEvent, CustomServerless, ServerlessFunction } from '../types/serverless-plugin.types';
 
+type PartialRecord<K extends keyof any, T> = Partial<Record<K, T>>;
+
 export default (
   serverless: CustomServerless
-): Record<'swaggerUI' | 'swaggerJSON' | 'swaggerRedirectURI', ServerlessFunction | undefined> => {
+): PartialRecord<'swaggerUI' | 'swaggerJSON' | 'swaggerRedirectURI', ServerlessFunction> => {
   const handlerPath = 'swagger/';
   const configInput = serverless?.configurationInput || serverless.service;
   const path = serverless.service.custom?.autoswagger?.swaggerPath ?? 'swagger';
@@ -66,6 +68,6 @@ export default (
   return {
     swaggerUI,
     swaggerJSON,
-    swaggerRedirectURI,
+    ...(swaggerRedirectURI && { swaggerRedirectURI }),
   };
 };

--- a/src/resources/functions.ts
+++ b/src/resources/functions.ts
@@ -1,7 +1,9 @@
 'use strict';
 import { ApiType, CustomHttpApiEvent, CustomServerless, ServerlessFunction } from '../types/serverless-plugin.types';
 
-export default (serverless: CustomServerless): Record<'swaggerUI' | 'swaggerJSON', ServerlessFunction> => {
+export default (
+  serverless: CustomServerless
+): Record<'swaggerUI' | 'swaggerJSON' | 'swaggerRedirectURI', ServerlessFunction | undefined> => {
   const handlerPath = 'swagger/';
   const configInput = serverless?.configurationInput || serverless.service;
   const path = serverless.service.custom?.autoswagger?.swaggerPath ?? 'swagger';
@@ -46,5 +48,24 @@ export default (serverless: CustomServerless): Record<'swaggerUI' | 'swaggerJSON
     ],
   };
 
-  return { swaggerUI, swaggerJSON };
+  const swaggerRedirectURI: ServerlessFunction | undefined = serverless.service.custom?.autoswagger?.useRedirectUI
+    ? {
+        name: name && stage ? `${name}-${stage}-swagger-redirect-uri` : undefined,
+        handler: handlerPath + 'oauth2-redirect-html.handler',
+        events: [
+          {
+            [apiType as 'httpApi']: {
+              method: 'get' as const,
+              path: useStage ? `/${stage}/oauth2-redirect.html` : `/oauth2-redirect.html`,
+            },
+          },
+        ],
+      }
+    : undefined;
+
+  return {
+    swaggerUI,
+    swaggerJSON,
+    swaggerRedirectURI,
+  };
 };

--- a/src/resources/oauth2-redirect-html.ts
+++ b/src/resources/oauth2-redirect-html.ts
@@ -1,0 +1,86 @@
+exports.handler = async () => {
+  return {
+    statusCode: 200,
+    body: redirectUI,
+    headers: {
+      'content-type': 'text/html',
+    },
+  };
+};
+
+// copied from view-source:https://unpkg.com/swagger-ui-dist@4.5.0/oauth2-redirect.html
+const redirectUI = `<!doctype html>
+<html lang="en-US">
+<head>
+    <title>Swagger UI: OAuth2 Redirect</title>
+</head>
+<body>
+<script>
+    'use strict';
+    function run () {
+        var oauth2 = window.opener.swaggerUIRedirectOauth2;
+        var sentState = oauth2.state;
+        var redirectUrl = oauth2.redirectUrl;
+        var isValid, qp, arr;
+
+        if (/code|token|error/.test(window.location.hash)) {
+            qp = window.location.hash.substring(1);
+        } else {
+            qp = location.search.substring(1);
+        }
+
+        arr = qp.split("&");
+        arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';});
+        qp = qp ? JSON.parse('{' + arr.join() + '}',
+                function (key, value) {
+                    return key === "" ? value : decodeURIComponent(value);
+                }
+        ) : {};
+
+        isValid = qp.state === sentState;
+
+        if ((
+          oauth2.auth.schema.get("flow") === "accessCode" ||
+          oauth2.auth.schema.get("flow") === "authorizationCode" ||
+          oauth2.auth.schema.get("flow") === "authorization_code"
+        ) && !oauth2.auth.code) {
+            if (!isValid) {
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "warning",
+                    message: "Authorization may be unsafe, passed state was changed in server Passed state wasn't returned from auth server"
+                });
+            }
+
+            if (qp.code) {
+                delete oauth2.state;
+                oauth2.auth.code = qp.code;
+                oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+            } else {
+                let oauthErrorMsg;
+                if (qp.error) {
+                    oauthErrorMsg = "["+qp.error+"]: " +
+                        (qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
+                        (qp.error_uri ? "More info: "+qp.error_uri : "");
+                }
+
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "error",
+                    message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server"
+                });
+            }
+        } else {
+            oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+        }
+        window.close();
+    }
+
+    window.addEventListener('DOMContentLoaded', function () {
+      run();
+    });
+</script>
+</body>
+</html>`;

--- a/src/resources/swagger-html.ts
+++ b/src/resources/swagger-html.ts
@@ -18,15 +18,50 @@ const swaggerUI = `<!DOCTYPE html>
       rel="stylesheet"
       href="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css"
     />
-
+    <script src="https://unpkg.com/react@15/dist/react.min.js"></script>
     <script src="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-bundle.js"></script>
     <script src="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-standalone-preset.js"></script>
     <script defer>
       window.onload = () => {
+        const h = React.createElement
         const ui = SwaggerUIBundle({
           url: window.location.href + '.json',
           dom_id: '#swagger-ui',
-          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset, 
+        system => {
+            // Variable to capture the security prop of OperationSummary
+            // then pass it to authorizeOperationBtn
+            let currentSecurity
+            return {
+                wrapComponents: {
+                    // Wrap OperationSummary component to get its prop
+                    OperationSummary: Original => props => {
+                        const security = props.operationProps.get('security')
+                        currentSecurity = security.toJS()
+                        return h(Original, props)
+                    },
+                    // Wrap the padlock button to show the
+                    // scopes required for current operation
+                    authorizeOperationBtn: Original =>
+                        function (props) {
+                            return h('div', {}, [
+                                ...(currentSecurity || []).map(scheme => {
+                                    const schemeName = Object.keys(scheme)[0]
+                                    if (!scheme[schemeName].length) return null
+
+                                    const scopes = scheme[schemeName].flatMap(scope => [
+                                        h('code', null, scope),
+                                        ', ',
+                                    ])
+                                    scopes.pop()
+                                    return h('span', null, scopes)
+                                }),
+                                h(Original, props),
+                            ])
+                        },
+                },
+            }
+        }],
           layout: 'StandaloneLayout',
         });
         window.ui = ui;

--- a/src/schemas/custom-properties.schema.json
+++ b/src/schemas/custom-properties.schema.json
@@ -86,6 +86,10 @@
           "default": "swagger",
           "type": "string"
         },
+        "useRedirectUI": {
+          "default": "false",
+          "type": "boolean"
+        },
         "typefiles": {
           "default": [],
           "items": {

--- a/src/types/serverless-plugin.types.d.ts
+++ b/src/types/serverless-plugin.types.d.ts
@@ -12,8 +12,10 @@ import type {
   Serverless,
 } from 'serverless/aws';
 import type { HttpMethod } from './common.types';
+import { MethodSecurity } from './swagger.types';
 
 export type CustomServerless = {
+  // eslint-disable-next-line no-unused-vars
   cli?: { log: (text: string) => void }; // deprecated and replaced in v3.0.0
   service: ServerlessConfig;
   configSchemaHandler: configSchemaHandler;
@@ -44,6 +46,7 @@ export interface AutoSwaggerCustomConfig {
   version?: string;
   excludeStages?: string[];
   lambdaAuthorizer?: Http['authorizer'] | HttpApiEvent['authorizer'];
+  useRedirectUI?: boolean;
 }
 
 export type CustomWithAutoSwagger = Custom & { autoswagger?: AutoSwaggerCustomConfig };
@@ -111,6 +114,7 @@ export interface CustomHttpEvent extends Http {
   headerParameters?: HeaderParameters;
   queryStringParameters?: QueryStringParameters;
   operationId?: string;
+  security?: MethodSecurity[];
 }
 
 export interface CustomHttpApiEvent extends HttpApiEvent {
@@ -127,6 +131,7 @@ export interface CustomHttpApiEvent extends HttpApiEvent {
   headerParameters?: string;
   queryStringParameterType?: string;
   operationId?: string;
+  security?: MethodSecurity[];
 }
 
 export interface HttpResponses {

--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -52,7 +52,7 @@ const getCustomServerlessConfig = ({ autoswaggerOptions }: GetCustomServerlessCo
 });
 
 describe('swaggerFunctions tests', () => {
-  it('includes blank if useRedirectUI is set to true', () => {
+  it('includes swaggerRedirectURI if useRedirectUI is set to true', () => {
     const serviceDetails = getCustomServerlessConfig({
       autoswaggerOptions: {
         useRedirectUI: true,
@@ -62,7 +62,7 @@ describe('swaggerFunctions tests', () => {
     expect(Object.keys(result)).toContain('swaggerRedirectURI');
   });
 
-  it('does not includes blank if useRedirectUI is set to false', () => {
+  it('does not includes swaggerRedirectURI if useRedirectUI is set to false', () => {
     const serviceDetails = getCustomServerlessConfig({
       autoswaggerOptions: {
         useRedirectUI: false,
@@ -72,7 +72,7 @@ describe('swaggerFunctions tests', () => {
     expect(Object.keys(result)).not.toContain('swaggerRedirectURI');
   });
 
-  it('does not includes blank if useRedirectUI is not set', () => {
+  it('does not includes swaggerRedirectURI if useRedirectUI is not set', () => {
     const serviceDetails = getCustomServerlessConfig();
     const result = swaggerFunctions(serviceDetails);
     expect(Object.keys(result)).not.toContain('swaggerRedirectURI');

--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -1,0 +1,80 @@
+import swaggerFunctions from '../src/resources/functions';
+import { AutoSwaggerCustomConfig, CustomServerless } from '../src/types/serverless-plugin.types';
+
+const defaultServiceDetails: CustomServerless = {
+  configSchemaHandler: {
+    defineCustomProperties: () => undefined,
+    defineFunctionEvent: () => undefined,
+    defineFunctionEventProperties: () => undefined,
+    defineFunctionProperties: () => undefined,
+    defineProvider: () => undefined,
+    defineTopLevelProperty: () => undefined,
+  },
+  configurationInput: {},
+  service: {
+    service: '',
+    provider: {
+      name: 'aws',
+      runtime: undefined,
+      stage: '',
+      region: undefined,
+      profile: '',
+      environment: {},
+    },
+    plugins: [],
+    functions: {
+      mocked: {
+        handler: 'mocked.handler',
+      },
+    },
+    custom: {
+      autoswagger: {},
+    },
+  },
+};
+
+type GetCustomServerlessConfigParams = {
+  autoswaggerOptions?: AutoSwaggerCustomConfig;
+};
+
+const getCustomServerlessConfig = ({ autoswaggerOptions }: GetCustomServerlessConfigParams = {}): CustomServerless => ({
+  ...defaultServiceDetails,
+  service: {
+    ...defaultServiceDetails.service,
+    custom: {
+      ...defaultServiceDetails.service.custom,
+      autoswagger: {
+        ...defaultServiceDetails.service.custom?.autoswagger,
+        ...autoswaggerOptions,
+      },
+    },
+  },
+});
+
+describe('swaggerFunctions tests', () => {
+  it('includes blank if useRedirectUI is set to true', () => {
+    const serviceDetails = getCustomServerlessConfig({
+      autoswaggerOptions: {
+        useRedirectUI: true,
+      },
+    });
+    const result = swaggerFunctions(serviceDetails);
+    expect(Object.keys(result)).toContain('swaggerRedirectURI');
+  });
+
+  it('does not includes blank if useRedirectUI is set to false', () => {
+    const serviceDetails = getCustomServerlessConfig({
+      autoswaggerOptions: {
+        useRedirectUI: false,
+      },
+    });
+    const result = swaggerFunctions(serviceDetails);
+    expect(Object.keys(result)).not.toContain('swaggerRedirectURI');
+  });
+
+  it('does not includes blank if useRedirectUI is not set', () => {
+    const serviceDetails = getCustomServerlessConfig();
+    const result = swaggerFunctions(serviceDetails);
+    expect(Object.keys(result)).not.toContain('swaggerRedirectURI');
+  });
+});


### PR DESCRIPTION
# Commit Message

* creating new parameter `useRedirectUI` that enables hosting an endpoint for using the standard OAuth 2.0 Authorization Code Grant Flow.

* Updating swagger plugin to include middleware that puts scopes next to the authorization widget for each endpoint

# Summary

Love the package you've put together, but wanted to make a couple modifications to better support authentication for my use case. I made the changes listed in the commits above and also just a couple minor clean up things around the code base. You can see my hosted version [here](https://api.arccosgolf.com/swagger), but you I can't give you credentials (work system). Let me know what you think!

# Example

Here's a screenshot of what the scope definition additions looks like:
<img width="1008" alt="Screen Shot 2022-11-21 at 12 43 58 PM" src="https://user-images.githubusercontent.com/75625191/203134910-82755052-a22f-42fc-8d29-24a2cd86b448.png">

Here's the swagger file I'm including in  to accomplish this:
```{
  "swagger": "2.0",
  "securityDefinitions": {
    "AccessCodeAuth": {
      "type": "oauth2",
      "flow": "accessCode",
      "authorizationUrl": "https://signin.arccosgolf.com/login",
      "tokenUrl": "https://signin.arccosgolf.com/oauth2/token",
      "oauth2RedirectUrl": "https://api.arccosgolf.com/swagger",
      "scopes": {
        "openid": "Required for all endpoints that have userId in the path",
        "arccos/read:rounds": "Grants read rounds access",
        "arccos/read:users": "Grants read users access"
      }
    }
  }
}
```

and here's an example `httpApi` `security` attribute I'm using:
```security: [
    {
        AccessCodeAuth: [
            `arccos/read:rounds`,
        ],
    },
],
```